### PR TITLE
Add Felipe to the editors.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-ietf-wpack-use-cases.md jyasskin@chromium.org
+draft-ietf-wpack-use-cases.md jyasskin@chromium.org felipeerias@igalia.com

--- a/draft-ietf-wpack-use-cases.md
+++ b/draft-ietf-wpack-use-cases.md
@@ -15,6 +15,10 @@ author:
     name: Jeffrey Yasskin
     organization: Google
     email: jyasskin@chromium.org
+ -
+    name: Felipe Erias
+    organization: Igalia
+    email: felipeerias@igalia.com
 
 informative:
   ISO28500:


### PR DESCRIPTION
@felipeerias, did I get your metadata right? The fields are defined at https://github.com/cabo/kramdown-rfc2629#the-yaml-header, which fills in https://datatracker.ietf.org/doc/html/rfc7991#section-2.7.