### PR TITLE
Initial reprioritization of use cases

### DIFF
--- a/draft-ietf-wpack-use-cases.md
+++ b/draft-ietf-wpack-use-cases.md
@@ -112,14 +112,14 @@ or perhaps with {{?I-D.ietf-httpbis-cache-digest}}.
 Associated requirements:
 
 * {{urls}}{:format="title"}
-* {{response-headers}}{:format="title"}: At least the Content-Type is needed to
-  load JS and CSS.
-* {{random-access}}{:format="title"}: To avoid needing a long linear scan before
-  using the content.
-* {{unsigned-content}}{:format="title"}: Signing same-origin content wastes
-  space.
 * {{streamed-loading}}{:format="title"}: To solve downside 1.
 * {{transfer-compression}}{:format="title"}: To keep the upside.
+* {{response-headers}}{:format="title"}: At least the Content-Type is needed to
+  load JS and CSS.
+* {{unsigned-content}}{:format="title"}: Signing same-origin content wastes
+  space.
+* {{random-access}}{:format="title"}: To avoid needing a long linear scan before
+  using the content.
 * {{binary}}{:format="title"}: Bundles may be stored in version control systems,
   and furthermore they are not expected to be created or read manually.
 


### PR DESCRIPTION
As discussed in the WPACK group, I have been working to move the controversial use cases to an informative appendix.

This first PR only moves some sections without changing their contents. Later on, we can have more specific PRs to rewrite some of those sections.

One of the main concerns about the Web Bundles proposal has been whether it could allow an origin to act on behalf of another without a client ever contacting the authoritative server. Therefore. my (very rough) initial approach has been to move to the Appendix those uses cases that required signing and/or that called for putting content from different origins inside a bundle.

This affected some use cases that are useful and not really controversial by themselves (e.g. saving a local copy of a website); in following PRs we can update their contents and move them to the main Use Cases section.